### PR TITLE
Adding interpolated boundary method for testing subsets

### DIFF
--- a/CovRateLvlSets.m
+++ b/CovRateLvlSets.m
@@ -1,4 +1,4 @@
-function [coveringRate] = CovRateLvlSets( truef, hatf, thresh, c )
+function [coveringRate] = CovRateLvlSets( truef, hatf, thresh, c, Bdry_test )
 
 % Compute covering rate of level sets
 % Input:
@@ -8,6 +8,8 @@ function [coveringRate] = CovRateLvlSets( truef, hatf, thresh, c )
 % thresh: array of size [size(truef), M, 2] corresponding to the thresholds for the
 %         hatf, [ , , 1] are lower bounds, [ , , 2] are upper bounds
 % c:      targeted levelset
+% Bdry_test: if 0, applies old boundary test comparing just binarized sets.
+%        if 1, also used lintear interpolation boundary test. 
 %Output:
 % coveringRate is computed from all available hatf and computes the
 % frequency that the true c-levelset of truef is completly contained in the
@@ -27,22 +29,45 @@ index = repmat( {':'}, 1, N+1 );
 
 truefm = reshape( repmat(reshape( truef, [prod(sf) 1] ), 1, M ) , [sf M] ) ;
 
-if ndims( thresh ) == N+2
-    coveringRate = 1-sum(any(reshape(...
-                ( truefm < c & (hatf >= squeeze(thresh(index{:},2))) ) |...
-                ( truefm >= c & (hatf < squeeze(thresh(index{:},1))))...
-               ,[prod(sf) M]), 1 )) / M ;
-else
-    nquantiles = size(thresh,N+1);
-    coveringRate = zeros(1,nquantiles);
-    index2 = repmat( {':'}, 1, N );
-    index3 = repmat( {':'}, 1, 2 );
-    
-    for i = 1:nquantiles
-        thresh_tmp = squeeze(thresh(index2{:}, i, index3{:}));
-        coveringRate(i) = 1-sum(any(reshape(...
-                ( truefm < c & (hatf >= squeeze(thresh_tmp(index{:},2))) ) |...
+% Finding the edges and weights for interpolating true field = c
+if ( Bdry_test )
+    bdry_params = getBdryparams(truef, c);
+    bdry_length = length(bdry_params.lshift.w1);
+    low_thresh_bdry_values  = zeros(bdry_length, M);
+    high_thresh_bdry_values = zeros(bdry_length, M);    
+    hatf_bdry_values        = zeros(bdry_length, M);   
+end
+
+nquantiles = size(thresh,N+1);
+coveringRate = zeros(1,nquantiles);
+index2 = repmat( {':'}, 1, N );
+index3 = repmat( {':'}, 1, 2 );
+
+for i = 1:nquantiles
+    thresh_tmp = squeeze(thresh(index2{:}, i, index3{:}));
+
+    if ( Bdry_test )
+        % finding values of estimated field at locations where true
+        % field = c 
+        for j = 1:M          
+            low_thresh_bdry_values(:,j)  = getBdryvalues(squeeze(thresh_tmp(index2{:},j,1)), bdry_params);
+            high_thresh_bdry_values(:,j) = getBdryvalues(squeeze(thresh_tmp(index2{:},j,2)), bdry_params);
+            hatf_bdry_values(:,j)        = getBdryvalues(hatf(index2{:},j), bdry_params);
+        end
+        violations = sum( ...
+            any(reshape(...
+                ( truefm < c & (hatf >= squeeze(thresh_tmp(index{:},2)))) |...
                 ( truefm >= c & (hatf < squeeze(thresh_tmp(index{:},1))))...
-               ,[prod(sf) M]), 1 )) / M ;
+            ,[prod(sf) M]), 1) | ...
+            any(...
+                hatf_bdry_values >= high_thresh_bdry_values | ...
+                hatf_bdry_values < low_thresh_bdry_values...
+            , 1 )) / M;
+    else 
+       violations = sum(any(reshape(...
+        ( truefm < c & (hatf >= squeeze(thresh_tmp(index{:},2))) ) |...
+        ( truefm >= c & (hatf < squeeze(thresh_tmp(index{:},1))))...
+       ,[prod(sf) M]), 1 )) / M ; 
     end
+    coveringRate(i) = 1-violations; 
 end

--- a/getBdryparams.m
+++ b/getBdryparams.m
@@ -1,0 +1,139 @@
+function [bdry_params] = getBdryparams(field, c)
+
+% Finds edges and weights needed to linearly interpolate a discretized field 
+% to find the locations where the true continuous field = c
+%
+% Input:
+% field:     random field over a domain in R^2, it is an (2+1)-dimensional array,
+%            where the last dimension enumerates realisations
+% c:         threshold value for excursion
+%
+%Output:
+% bdry_params is a struct containing the edge locations either side of the
+% true continuous boundary where the field = c, as well as the weights that
+% the adjacent voxels need to be multiplied by to give the precise location where the 
+% field = c assuming that the gradient of the signal is linear between adjacent
+% voxels. 
+%
+%__________________________________________________________________________
+% References:
+%__________________________________________________________________________
+% Author: Alex Bowring (alex.bowring@bdi.ox.ac.uk)
+% Last changes: 10/25/2018
+%__________________________________________________________________________
+
+
+A_c = (field >= c);
+dim = size(A_c);
+D   = length(dim);
+
+switch D
+    case 2
+        %%%%%%%%%%%%%%%% Case 2D random field with 4-connectivity %%%%%%%%%%%%%%%%%
+        %%%%%% Horizontal edges (note that this uses the matlab image nomenclature,
+        %%%%%% usually the second component might be called vertical)
+        horz = A_c(:,2:end) | A_c(:,1:end-1);
+        %%% Compute the left shifted horizontal edges
+        lshift            = A_c; % initialize
+        lshift(:,1:end-1) = horz;
+        lshift            = lshift & ~A_c;
+        %%% Compute the right shifted horizontal edges
+        rshift          = A_c; % initialize
+        rshift(:,2:end) = horz;
+        rshift          = rshift & ~A_c;
+        %%%%%% Vertical edges (note that this uses the matlab image nomenclature,
+        %%%%%% usually the first component might be called horizontal)
+        vert = A_c(1:end-1,:) | A_c(2:end,:);
+        %%% Compute the right shifted horizontal edges
+        ushift = A_c;
+        ushift(1:end-1,:) = vert;
+        ushift = ushift & ~A_c;
+        %%% Compute the down shifted vertical edges
+        dshift = A_c;
+        dshift(2:end,:)   = vert;
+        dshift = dshift & ~A_c;
+        
+        % Computing the weights for the weighted linear boundary of the
+        % field
+        lshift_w1 = abs(field(lshift(:,[dim(2) 1:dim(2)-1])) - c)./abs(field(lshift) - field(lshift(:,[dim(2) 1:dim(2)-1])));
+        lshift_w2 = abs(field(lshift) - c)./abs(field(lshift) - field(lshift(:,[dim(2) 1:dim(2)-1])));
+
+        rshift_w1 = abs(field(rshift(:,[2:dim(2) 1])) - c)./abs(field(rshift) - field(rshift(:,[2:dim(2) 1])));
+        rshift_w2 = abs(field(rshift) - c)./abs(field(rshift) - field(rshift(:,[2:dim(2) 1])));
+
+        ushift_w1 = abs(field(ushift([dim(1) 1:dim(1)-1],:)) - c)./abs(field(ushift) - field(ushift([dim(1) 1:dim(1)-1],:)));
+        ushift_w2 = abs(field(ushift) - c)./abs(field(ushift) - field(ushift([dim(1) 1:dim(1)-1],:)));
+
+        dshift_w1 = abs(field(dshift([2:dim(1) 1],:)) - c)./abs(field(dshift) - field(dshift([2:dim(1) 1],:)));
+        dshift_w2 = abs(field(dshift) - c)./abs(field(dshift) - field(dshift([2:dim(1) 1],:)));
+        
+        % Storing parameters in a structure
+        bdry_params = struct('lshift', struct('edges', lshift, 'w1', lshift_w1,'w2', lshift_w2), ...
+                             'rshift', struct('edges', rshift, 'w1', rshift_w1,'w2', rshift_w2), ...
+                             'ushift', struct('edges', ushift, 'w1', ushift_w1,'w2', ushift_w2), ...
+                             'dshift', struct('edges', dshift ,'w1', dshift_w1,'w2', dshift_w2));
+                         
+    case 3
+        %%%%%%%%%%%%%%%% Case 3D random field with 6-connectivity %%%%%%%%%%%%%%%%%
+        %%%%%% Horizontal edges (note that this uses the matlab image nomenclature,
+        %%%%%% usually the second component might be called vertical)
+        horz = A_c(:,2:end,:) | A_c(:,1:end-1,:);
+        %%% Compute the left shifted horizontal edges
+        lshift              = A_c; % initialize
+        lshift(:,1:end-1,:) = horz;
+        lshift              = lshift & ~A_c;
+        %%% Compute the right shifted horizontal edges
+        rshift            = A_c; % initialize
+        rshift(:,2:end,:) = horz;
+        rshift            = rshift & ~A_c;
+        %%%%%% Vertical edges (note that this uses the matlab image nomenclature,
+        %%%%%% usually the first component might be called horizontal)
+        vert = A_c(1:end-1,:,:) | A_c(2:end,:,:);
+        %%% Compute the right shifted horizontal edges
+        ushift = A_c;
+        ushift(1:end-1,:,:) = vert;
+        ushift = ushift & ~A_c;
+        %%% Compute the down shifted vertical edges
+        dshift = A_c;
+        dshift(2:end,:,:)   = vert;
+        dshift = dshift & ~A_c;
+        %%%%%% depth edges
+        depth = A_c(:,:,1:end-1) | A_c(:,:,2:end);
+        %%% Compute the back shifted depth edges
+        bshift = A_c;
+        bshift(:,:,1:end-1) = depth;
+        bshift = bshift & ~A_c;
+        %%% Compute the fron shifted depth edges
+        fshift = A_c;
+        fshift(:,:,2:end)   = depth;
+        fshift = fshift & ~A_c;
+
+        % Computing the weights for the weighted linear boundary of the
+        % field
+        lshift_w1 = abs(field(lshift(:,[dim(2) 1:dim(2)-1],:)) - c)./abs(field(lshift) - field(lshift(:,[dim(2) 1:dim(2)-1],:)));
+        lshift_w2 = abs(field(lshift) - c)./abs(field(lshift) - field(lshift(:,[dim(2) 1:dim(2)-1],:)));
+
+        rshift_w1 = abs(field(rshift(:,[2:dim(2) 1],:)) - c)./abs(field(rshift) - field(rshift(:,[2:dim(2) 1],:)));
+        rshift_w2 = abs(field(rshift) - c)./abs(field(rshift) - field(rshift(:,[2:dim(2) 1],:)));
+
+        ushift_w1 = abs(field(ushift([dim(1) 1:dim(1)-1],:,:)) - c)./abs(field(ushift) - field(ushift([dim(1) 1:dim(1)-1],:,:)));
+        ushift_w2 = abs(field(ushift) - c)./abs(field(ushift) - field(ushift([dim(1) 1:dim(1)-1],:,:)));
+
+        dshift_w1 = abs(field(dshift([2:dim(1) 1],:,:)) - c)./abs(field(dshift) - field(dshift([2:dim(1) 1],:,:)));
+        dshift_w2 = abs(field(dshift) - c)./abs(field(dshift) - field(dshift([2:dim(1) 1],:,:)));
+
+        bshift_w1 = abs(field(bshift(:,:,[dim(3) 1:dim(3)-1])) - c)./abs(field(bshift) - field(bshift(:,:,[dim(3) 1:dim(3)-1])));
+        bshift_w2 = abs(field(bshift) - c)./abs(field(bshift) - field(bshift(:,:,[dim(3) 1:dim(3)-1])));
+
+        fshift_w1 = abs(field(fshift(:,:,[2:dim(3) 1])) - c)./abs(field(fshift) - field(fshift(:,:,[2:dim(3) 1])));
+        fshift_w2 = abs(field(fshift) - c)./abs(field(fshift) - field(fshift(:,:,[2:dim(3) 1])));
+        
+        % Create structure for storing parameters
+        bdry_params = struct('lshift', struct('edges', lshift, 'w1', lshift_w1,'w2', lshift_w2), ...
+                             'rshift', struct('edges', rshift, 'w1', rshift_w1,'w2', rshift_w2), ...
+                             'ushift', struct('edges', ushift, 'w1', ushift_w1,'w2', ushift_w2), ...
+                             'dshift', struct('edges', dshift ,'w1', dshift_w1,'w2', dshift_w2), ...
+                             'bshift', struct('edges', bshift ,'w1', bshift_w1,'w2', bshift_w2), ...
+                             'fshift', struct('edges', fshift ,'w1', fshift_w1,'w2', fshift_w2));        
+end
+

--- a/getBdryvalues.m
+++ b/getBdryvalues.m
@@ -1,0 +1,27 @@
+function [bdry_values] = getBdryvalues(field, bdry_params)
+
+dim = size(field);
+D   = length(dim);
+
+switch D
+    case 2
+        lshift_bdry_values = bdry_params.lshift.w1.*field(bdry_params.lshift.edges) + bdry_params.lshift.w2.*field(bdry_params.lshift.edges(:,[dim(2) 1:dim(2)-1]));
+        rshift_bdry_values = bdry_params.rshift.w1.*field(bdry_params.rshift.edges) + bdry_params.rshift.w2.*field(bdry_params.rshift.edges(:,[2:dim(2) 1]));
+        ushift_bdry_values = bdry_params.ushift.w1.*field(bdry_params.ushift.edges) + bdry_params.ushift.w2.*field(bdry_params.ushift.edges([dim(1) 1:dim(1)-1],:));
+        dshift_bdry_values = bdry_params.dshift.w1.*field(bdry_params.dshift.edges) + bdry_params.dshift.w2.*field(bdry_params.dshift.edges([2:dim(1) 1],:));
+
+        bdry_values = [lshift_bdry_values; rshift_bdry_values; ushift_bdry_values; dshift_bdry_values];
+
+    case 3
+        lshift_bdry_values = bdry_params.lshift.w1.*field(bdry_params.lshift.edges) + bdry_params.lshift.w2.*field(bdry_params.lshift.edges(:,[dim(2) 1:dim(2)-1],:));
+        rshift_bdry_values = bdry_params.rshift.w1.*field(bdry_params.rshift.edges) + bdry_params.rshift.w2.*field(bdry_params.rshift.edges(:,[2:dim(2) 1],:));
+        ushift_bdry_values = bdry_params.ushift.w1.*field(bdry_params.ushift.edges) + bdry_params.ushift.w2.*field(bdry_params.ushift.edges([dim(1) 1:dim(1)-1],:,:));
+        dshift_bdry_values = bdry_params.dshift.w1.*field(bdry_params.dshift.edges) + bdry_params.dshift.w2.*field(bdry_params.dshift.edges([2:dim(1) 1],:,:));
+        bshift_bdry_values = bdry_params.bshift.w1.*field(bdry_params.bshift.edges) + bdry_params.bshift.w2.*field(bdry_params.bshift.edges(:,:,[dim(3) 1:dim(3)-1]));
+        fshift_bdry_values = bdry_params.fshift.w1.*field(bdry_params.fshift.edges) + bdry_params.fshift.w2.*field(bdry_params.fshift.edges(:,:,[2:dim(3) 1]));
+        
+        bdry_values = [lshift_bdry_values; rshift_bdry_values; ushift_bdry_values; dshift_bdry_values, bshift_bdry_values, fshift_bdry_values];
+end
+end 
+   
+     


### PR DESCRIPTION
This PR contains the `getBdryparams.m` and `getBdryvalues.m` function, and modifies the `CovRateLvlSets.m` to use the interpolated boundary subset test. 